### PR TITLE
Missing headers won't cause key not found exception

### DIFF
--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit.Sample/MessageSender.cs
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit.Sample/MessageSender.cs
@@ -9,10 +9,14 @@ namespace Server
 
         public void Start()
         {
-            Bus.SendLocal(new Message1
+            Console.WriteLine("Press Enter to start a saga");
+            while (Console.ReadLine() != null)
+            {
+                Bus.SendLocal(new Message1
                 {
                     SomeId = Guid.NewGuid()
                 });
+            }
         }
 
         public void Stop()

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/ServiceControl.Plugin.Nsb5.SagaAudit.Tests.csproj
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/ServiceControl.Plugin.Nsb5.SagaAudit.Tests.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8654E090-6007-4476-A769-AE8B08C44E63}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ServiceControl.Plugin.Nsb5.SagaAudit.Tests</RootNamespace>
+    <AssemblyName>ServiceControl.Plugin.Nsb5.SagaAudit.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NServiceBus.Core">
+      <HintPath>..\packages\NServiceBus.5.1.3\lib\net45\NServiceBus.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="When_a_message_with_proper_headers_arrive.cs" />
+    <Compile Include="When_a_message_with_no_headers_arrive.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceControl.Plugin.Nsb5.SagaAudit\ServiceControl.Plugin.Nsb5.SagaAudit.csproj">
+      <Project>{97079a73-235e-4d52-a6df-ebf3bf0f4971}</Project>
+      <Name>ServiceControl.Plugin.Nsb5.SagaAudit</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/When_a_message_with_no_headers_arrive.cs
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/When_a_message_with_no_headers_arrive.cs
@@ -1,0 +1,27 @@
+﻿namespace ServiceControl.Plugin.Nsb5.SagaAudit.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using ServiceControl.Plugin.SagaAudit;
+
+    public class When_a_message_with_no_headers_arrive 
+    {
+        [Test]
+        public void Saga_state_change_message_can_be_created()
+        {
+            var behavior = new CaptureSagaStateBehavior(null, null, null);
+            var headers = new Dictionary<string, string>();
+            var messageId = Guid.NewGuid().ToString();
+            var messageType = "SomeMessage";
+
+            var message = behavior.BuildSagaChangeInitatorMessage(headers, messageId, messageType);
+
+            Assert.IsNotNull(message);
+            Assert.IsNullOrEmpty(message.OriginatingEndpoint);
+            Assert.IsNullOrEmpty(message.OriginatingMachine);
+            Assert.IsFalse(message.IsSagaTimeoutMessage);
+            Assert.AreEqual(DateTime.MinValue, message.TimeSent); // When SC can handle null TimeSent, then should be asserting to null, instead of checking for minValue
+        }
+    }
+}

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/When_a_message_with_proper_headers_arrive.cs
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/When_a_message_with_proper_headers_arrive.cs
@@ -13,7 +13,7 @@
             var behavior = new CaptureSagaStateBehavior(null, null, null);
           
 
-            var headers = new Dictionary<string, string>()
+            var headers = new Dictionary<string, string>
             {
                 {"NServiceBus.MessageId", "cf79765e-0123-45bf-a41b-a42d00a867c9"},
                 {"NServiceBus.CorrelationId", "cf79765e-0123-45bf-a41b-a42d00a867c9"},

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/When_a_message_with_proper_headers_arrive.cs
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/When_a_message_with_proper_headers_arrive.cs
@@ -1,0 +1,51 @@
+﻿namespace ServiceControl.Plugin.Nsb5.SagaAudit.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using ServiceControl.Plugin.SagaAudit;
+
+    public class When_a_message_with_proper_headers_arrive
+    {
+        [Test]
+        public void Saga_state_change_message_can_be_created()
+        {
+            var behavior = new CaptureSagaStateBehavior(null, null, null);
+          
+
+            var headers = new Dictionary<string, string>()
+            {
+                {"NServiceBus.MessageId", "cf79765e-0123-45bf-a41b-a42d00a867c9"},
+                {"NServiceBus.CorrelationId", "cf79765e-0123-45bf-a41b-a42d00a867c9"},
+                {"NServiceBus.MessageIntent", "Send"},
+                {"NServiceBus.Version", "5.1.2"},
+                {"NServiceBus.TimeSent", "2015-01-27 18:13:08:723699 Z"},
+                {"NServiceBus.ContentType", "application/json"},
+                {"NServiceBus.EnclosedMessageTypes", "Message1, ServiceControl.Plugin.SagaAudit.Sample, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"},
+                {"CorrId",@"cf79765e-0123-45bf-a41b-a42d00a867c9\0"},
+                {"NServiceBus.ConversationId", "be34099f-1e50-4ec6-b935-a42d00a8681d"},
+                {"WinIdName",@"MACHINE\user1"},
+                {"NServiceBus.OriginatingMachine", "MACHINE"},
+                {"NServiceBus.OriginatingEndpoint","ServiceControl.Plugin.SagaAudit.Sample"},
+                {"$.diagnostics.originating.hostid","8c436a19575e17e429c033fe4ab595fd"},
+                {"NServiceBus.ReplyToAddress","ServiceControl.Plugin.SagaAudit.Sample@MACHINE"},
+                {"$.diagnostics.hostid","8c436a19575e17e429c033fe4ab595fd"},
+                {"$.diagnostics.hostdisplayname","MACHINE"},
+                {"$.diagnostics.license.expired","false"},
+                {"NServiceBus.InvokedSagas","MySaga:da6bb5a2-9b3a-4ef2-8c7b-a42d00a86aa5"},
+                {"NServiceBus.IsSagaTimeoutMessage","true"}
+            };
+
+            var messageId = Guid.NewGuid().ToString();
+            const string messageType = "Message1";
+
+            var message = behavior.BuildSagaChangeInitatorMessage(headers, messageId, messageType);
+
+            Assert.IsNotNull(message);
+            Assert.IsNotNullOrEmpty(message.OriginatingEndpoint);
+            Assert.IsNotNullOrEmpty(message.OriginatingMachine);
+            Assert.IsTrue(message.IsSagaTimeoutMessage);
+            Assert.AreNotEqual(DateTime.MinValue, message.TimeSent); // When SC can handle null TimeSent, then should be asserting to null, instead of checking for minValue
+        }
+    }
+}

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/app.config
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/packages.config
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="5.1.3" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+</packages>

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit.sln
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Plugin.Nsb5.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Plugin.Nsb5.SagaAudit.Sample", "ServiceControl.Plugin.Nsb5.SagaAudit.Sample\ServiceControl.Plugin.Nsb5.SagaAudit.Sample.csproj", "{E661AC36-B063-46C0-8BB6-8488AC68727F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceControl.Plugin.Nsb5.SagaAudit.Tests", "ServiceControl.Plugin.Nsb5.SagaAudit.Tests\ServiceControl.Plugin.Nsb5.SagaAudit.Tests.csproj", "{8654E090-6007-4476-A769-AE8B08C44E63}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{E661AC36-B063-46C0-8BB6-8488AC68727F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E661AC36-B063-46C0-8BB6-8488AC68727F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E661AC36-B063-46C0-8BB6-8488AC68727F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8654E090-6007-4476-A769-AE8B08C44E63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8654E090-6007-4476-A769-AE8B08C44E63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8654E090-6007-4476-A769-AE8B08C44E63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8654E090-6007-4476-A769-AE8B08C44E63}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit/AssemblyInfo.cs
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle("ServiceControl.Plugin.SagaAudit")]
-[assembly: AssemblyProduct("ServiceControl.Plugin.SagaAudit")]
-[assembly: InternalsVisibleTo("ServiceControl.UnitTests")]
+[assembly: AssemblyTitle("ServiceControl.Plugin.Nsb5.SagaAudit")]
+[assembly: AssemblyProduct("ServiceControl.Plugin.Nsb5.SagaAudit")]
+[assembly: InternalsVisibleTo("ServiceControl.Plugin.Nsb5.SagaAudit.Tests")]

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit/CaptureSagaStateBehavior.cs
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit/CaptureSagaStateBehavior.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.Remoting.Messaging;
     using EndpointPlugin.Messages.SagaState;
     using NServiceBus;
     using NServiceBus.Pipeline;
@@ -10,7 +9,6 @@
     using NServiceBus.Saga;
     using NServiceBus.Sagas;
     using NServiceBus.Transports;
-    using NServiceBus.Unicast.Messages;
 
     class CaptureSagaStateBehavior : IBehavior<IncomingContext>
     {

--- a/src/ServiceControl.Plugin.Nsb5.SagaAudit/Messages/SagaChangeInitiator.cs
+++ b/src/ServiceControl.Plugin.Nsb5.SagaAudit/Messages/SagaChangeInitiator.cs
@@ -7,7 +7,7 @@ namespace ServiceControl.EndpointPlugin.Messages.SagaState
         public string InitiatingMessageId { get; set; }
         public string MessageType { get; set; }
         public bool IsSagaTimeoutMessage { get; set; }
-        public DateTime TimeSent { get; set; }
+        public DateTime? TimeSent { get; set; }
         public string OriginatingMachine { get; set; }
         public string OriginatingEndpoint { get; set; }
         public string Intent { get; set; }


### PR DESCRIPTION
If a message does not contain the OriginatingMachine, OriginatingEndpoint and TimeSent headers, message will still be audited. Fixes #2
